### PR TITLE
Circular referencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,10 @@ This is a standard npm module, so you'll install it via
 
 ```js
 var jsonRedactor = require('json-redactor')({
-  max: // int, default is 10
   watchKeys: // array of regex values, default is an empty array
   error: // string, default is '-'
 })
 ```
-`max` is the maximum number of recursions to go, deeper than max gets reset to ''.
-This is done so that recursive structures dont error out with a stack overflow.
-
 `watchKeys` is the list of things to watch for, only accepts regex
 
 `error` is the error message to replace strings that match the watchKeys with.
@@ -38,9 +34,8 @@ This is done so that recursive structures dont error out with a stack overflow.
 ```js
 var bole = require('bole');
 var jsonRedactor = require('./logFilter.js')({
-    watchKeys : [ /firstName/gi , /lastName/gi , /phone/gi ],
-    error: 'Dont Log sensitive data',
-    max: 5
+    watchKeys : [ /firstName/gi , /lastName/gi , /phone/gi , /^_.*/ ],
+    error: 'Dont Log sensitive data'
   });
 
 var b = bole(name)

--- a/index.js
+++ b/index.js
@@ -21,14 +21,14 @@ module.exports = function (opts) {
       })
     }
 
-    function internalSwap (el, cnt) {
+    function internalSwap (el) {
       if (typeof el === 'string') {
         if (firstRegexMatch(el)) {
           el = ERR
         }
       } else if (Array.isArray(el)) {
-        el = map(el, function (el) {
-          return internalSwap(el, cnt)
+        el = map(el, function (i) {
+          return internalSwap(i)
         })
       } else if (isObject(el)) {
         var index = gcache.indexOf(el)
@@ -39,7 +39,7 @@ module.exports = function (opts) {
         var cache = {}
         forOwn(el, function (v, k) {
           if (!firstRegexMatch(k)) {
-            cache[k] = internalSwap(v, cnt)
+            cache[k] = internalSwap(v)
           }
         })
         el = cache
@@ -49,7 +49,7 @@ module.exports = function (opts) {
 
     var cleaned = {}
     forOwn(arguments, function (v, k) {
-      cleaned[k] = internalSwap(v, 0)
+      cleaned[k] = internalSwap(v)
     })
     return cleaned
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-redactor",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "removes key value pairs from json objects, or redacts strings, if they contain regex keywords",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "removes key value pairs from json objects, or redacts strings, if they contain regex keywords",
   "main": "index.js",
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
     "lodash.find": "^4.6.0",
     "lodash.forown": "^4.4.0",
     "lodash.isobject": "^3.0.2",

--- a/test.js
+++ b/test.js
@@ -7,8 +7,7 @@ var ERROR_MESSAGE = 'TEST'
 
 var jsonRedactor = require('./index.js')({
   error: ERROR_MESSAGE,
-  watchKeys: WATCH_KEYS,
-  max: 5
+  watchKeys: WATCH_KEYS
 })
 
 var triggers = ['firstName', 'lastName', 'phone', 'phoneNumber', 'standardfirstname']
@@ -95,15 +94,18 @@ describe('json redactor', function () {
     })
   })
 
-  describe('removes elements that are too deep', function () {
-    // max = 5
-    it('in a 5D array, it removes the strings', function () {
-      var t = [[[triggers]]]
-      assertion(t, [[[['', '', '', '', '']]]])
+  describe('covers elements that are circular', function () {
+    it('replaces circular references with `[circular]`', function () {
+      var t = {a: 1, b: 2}
+      t.c = t
+      var test = {a: 1, b: 2, c: '[circular]'}
+      assertion(t, test)
     })
-    it('in a 6D array, it removes the array', function () {
-      var t = [[[[triggers]]]]
-      assertion(t, [[[['']]]])
+    it('it still works on deep references', function () {
+      var t = {a: 1, b: 2}
+      t.c = {d: t}
+      var test = {a: 1, b: 2, c: {d: '[circular]'}}
+      assertion(t, test)
     })
   })
 


### PR DESCRIPTION
circular referencing was causing issues, so originally we introduced a recursion limit to get around this, instead, we now make a temporary object cache that sees if the `Array.indexOf` finds a match